### PR TITLE
Changed project groupId to match github.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>nl.uu.cs.aplib</groupId>
+  <groupId>com.github.iv4xr-project</groupId>
   <artifactId>aplib</artifactId>
   <version>1.2.0</version>
 


### PR DESCRIPTION
Does groupId have to be nl.uu.cs.aplib? If not, let's change it to match groupId based on github location.
That way jitpack dependency is automatically possible using same groupId as when using maven local.

Projects using this library then don't have to install this library manually to maven local to use it.
Artifact on jitpack:
https://jitpack.io/#iv4xr-project/aplib/v1.2.0
https://jitpack.io/#iv4xr-project/aplib/master-SNAPSHOT

While will potentially make usage a lot easier for library users (especially new ones), current users of library would have to update this dependency for newer versions.
Another thing to consider here is versioning. To ensure compatibility, versioning should occur more often in case library becomes used more (ideally follow semver).