### PR TITLE
Suggestion for WorldEntity interface.

### DIFF
--- a/src/main/java/eu/iv4xr/framework/interop/IPositionable.java
+++ b/src/main/java/eu/iv4xr/framework/interop/IPositionable.java
@@ -1,0 +1,14 @@
+package eu.iv4xr.framework.interop;
+
+import eu.iv4xr.framework.spatial.Vec3;
+
+public interface IPositionable {
+    Vec3 getPosition();
+
+    Vec3 getVelocity();
+
+    /**
+     * agent's dimension (x,y,z size/2)
+     */
+    Vec3 getExtent();
+}

--- a/src/main/java/eu/iv4xr/framework/interop/IWorldEntity.java
+++ b/src/main/java/eu/iv4xr/framework/interop/IWorldEntity.java
@@ -1,0 +1,24 @@
+package eu.iv4xr.framework.interop;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * WorldEntity should not manage it's previous states and versions. Some other high-level object should do that.
+ * linkPreviousState, getPreviousState, hasPreviousState, etc.
+ *
+ * wrappers for accessing properties seems unnecessary
+ */
+public interface IWorldEntity extends IPositionable {
+    String getId();
+    String getType();
+    long getTimestamp();
+    /**
+     * If true then this entity is "dynamic", which means that its state may change at the runtime.
+     * Note that an entity does not have to be moving (having velocity) to be dynamic.
+     */
+    boolean isDynamic();
+    Map<String, Serializable> getProperties();
+    Map<String, ? extends IWorldEntity> getElements();
+
+}

--- a/src/main/java/eu/iv4xr/framework/mainConcepts/WorldEntity.java
+++ b/src/main/java/eu/iv4xr/framework/mainConcepts/WorldEntity.java
@@ -3,52 +3,27 @@ package eu.iv4xr.framework.mainConcepts;
 import java.io.*;
 import java.util.*;
 
+import eu.iv4xr.framework.interop.IWorldEntity;
 import eu.iv4xr.framework.spatial.Vec3;
 
-public class WorldEntity implements Serializable {
+public class WorldEntity implements Serializable, IWorldEntity {
 
-    /**
-     * A unique id identifying this entity.
-     */
-    public final String id;
+    private final String id;
 
-    /**
-     * The type-name of the entity, e.g. "door".
-     */
-    public final String type;
+    private final String type;
 
-    /**
-     * Represent the last time the state of this entity is sampled.
-     */
-    public long timestamp = -1;
+    private long timestamp = -1;
 
-    /**
-     * The last time the state of this entity is sampled, after which its state is
-     * always sampled to be the same as its current state (the start of stutter
-     * period towards the current state). If the value is -1, if this time is not
-     * known.
-     */
-    public long lastStutterTimestamp = -1;
+    private long lastStutterTimestamp = -1;
 
-    /**
-     * The center position of this entity,
-     */
-    public Vec3 position;
-    /**
-     * Bounding box of this entity.
-     */
-    public Vec3 extent; // bounding box
-    public Vec3 velocity;
+    private Vec3 position;
+    private Vec3 extent; // bounding box
+    private Vec3 velocity;
 
-    /**
-     * If true then this entity is "dynamic", which means that its state may change
-     * at the runtime. Note that an entity does not have to be moving (having
-     * velocity) to be dynamic.
-     */
-    public final boolean dynamic;
-    public Map<String, Serializable> properties = new HashMap<>();
+    private final boolean dynamic;
+    private Map<String, Serializable> properties = new HashMap<>();
 
-    public Map<String, WorldEntity> elements = new HashMap<>();
+    private Map<String, WorldEntity> elements = new HashMap<>();
 
     public WorldEntity(String id, String type, boolean dynamic) {
         this.id = id;
@@ -62,110 +37,100 @@ public class WorldEntity implements Serializable {
     private WorldEntity previousState = null;
 
     private boolean equal_(Object a, Object b) {
-        if (a == null)
-            return b == null;
+        if (a == null) return b == null;
         return a.equals(b);
     }
 
     /**
-     * Let e be non-null and represent the same entity as this entity (they have the
-     * same ID), but its state is possibly different than this entity. This method
-     * checks if both entity have the same state.
-     * 
-     * Dynamic entity is assumed not to change state. Else this method first check
-     * the hash-value of both entities. If they are the same, this method performs
-     * deep comparison of position, velocity, properties, and sub-entities. This
-     * might be a bit expensive; override this method if a faster implementation is
-     * wanted.
+     * Let e be non-null and represent the same entity as this entity (they have the same ID), but
+     * its state is possibly different than this entity. This method checks if both entity have
+     * the same state.
+     * <p>
+     * Dynamic entity is assumed not to change state. Else this method first check the hash-value
+     * of both entities. If they are the same, this method performs deep comparison of position,
+     * velocity, properties, and sub-entities. This might be a bit expensive; override this method
+     * if a faster implementation is wanted.
      */
     public boolean hasSameState(WorldEntity old) {
 
         // non-dynamic entity cannot change state:
-        if (!this.dynamic)
-            return true;
+        if (!this.isDynamic()) return true;
         // else:
-        if (this.hashCode() != old.hashCode())
-            return false;
+        if (this.hashCode() != old.hashCode()) return false;
 
-        if (!(equal_(position, old.position) && equal_(velocity, old.velocity)
-                && properties.size() == old.properties.size() && equal_(extent, old.extent)))
+        if (!(equal_(getPosition(), old.getPosition())
+                && equal_(getVelocity(), old.getVelocity())
+                && getProperties().size() == old.getProperties().size()
+                && equal_(getExtent(), old.getExtent())))
             return false;
-        for (var P : properties.entrySet()) {
-            var q = old.properties.get(P.getKey());
-            if (!P.getValue().equals(q))
-                return false;
+        for (var P : getProperties().entrySet()) {
+            var q = old.getProperties().get(P.getKey());
+            if (!P.getValue().equals(q)) return false;
         }
         // so the entities have the same properties.. let's now check the children
-        if (this.elements.size() != old.elements.size())
-            return false;
-        for (var elem_ : elements.entrySet()) {
-            var elem2 = old.elements.get(elem_.getKey());
-            if (elem2 == null)
-                return false;
+        if (this.getElements().size() != old.getElements().size()) return false;
+        for (var elem_ : getElements().entrySet()) {
+            var elem2 = old.getElements().get(elem_.getKey());
+            if (elem2 == null) return false;
             var elem1 = elem_.getValue();
-            if (!elem1.hasSameState(elem2))
-                return false;
+            if (!elem1.hasSameState(elem2)) return false;
         }
         return true;
     }
 
     public Serializable getProperty(String propertyName) {
-        return properties.get(propertyName);
+        return getProperties().get(propertyName);
     }
 
     public boolean getBooleanProperty(String propertyName) {
         var V = getProperty(propertyName);
-        if (V == null)
-            return false;
+        if (V == null) return false;
         if (!(V instanceof Boolean))
-            throw new IllegalArgumentException(id + " has no boolean property " + propertyName);
+            throw new IllegalArgumentException(getId() + " has no boolean property " + propertyName);
         return (boolean) V;
     }
 
     public String getStringProperty(String propertyName) {
         var V = getProperty(propertyName);
-        if (V == null)
-            return null;
+        if (V == null) return null;
         return V.toString();
     }
 
     public int getIntProperty(String propertyName) {
         var V = getProperty(propertyName);
         if (V == null || !(V instanceof Integer))
-            throw new IllegalArgumentException(id + " has no integer property " + propertyName);
+            throw new IllegalArgumentException(getId() + " has no integer property " + propertyName);
         return (int) V;
     }
 
     /**
-     * This will link e as the previous state of this Entity. The previous state of
-     * e is cleared to null (we only want to track the history of past state up to
-     * length 1).
-     * 
-     * This method assume that e represents the same Entity as this Entity (e.g.
-     * they have the same id).
+     * This will link e as the previous state of this Entity. The previous
+     * state of e is cleared to null (we only
+     * want to track the history of past state up to length 1).
+     * <p>
+     * This method assume that e represents the same Entity as this Entity
+     * (e.g. they have the same id).
      */
     public void linkPreviousState(WorldEntity e) {
         this.previousState = e;
-        if (e != null)
-            e.previousState = null;
+        if (e != null) e.previousState = null;
     }
 
     /**
-     * Return a WorldEntity representing this entity's previous state, if that is
-     * tracked.
+     * Return a WorldEntity representing this entity's previous state, if that is tracked.
      */
     public WorldEntity getPreviousState() {
         return previousState;
     }
 
     /**
-     * True if this entity has no previous state, or if its state differs from its
-     * previous. Note that we only track 1x previous state (so there is no longer
+     * True if this entity has no previous state, or if its state differs
+     * from its previous.
+     * Note that we only track 1x previous state (so there is no longer
      * chain of previous states).
      */
     public boolean hasChangedState() {
-        if (previousState == null)
-            return true;
+        if (previousState == null) return true;
         return !hasSameState(previousState);
     }
 
@@ -177,18 +142,17 @@ public class WorldEntity implements Serializable {
      * Set the time-stamp of this Entity and its elements to the given time.
      */
     public void assignTimeStamp(long ts) {
-        timestamp = ts;
-        for (var e : elements.values())
-            e.assignTimeStamp(ts);
+        setTimestamp(ts);
+        for (var e : getElements().values()) e.assignTimeStamp(ts);
     }
 
     /**
      * If true then this entity is a moving entity. This is defined as having a
-     * non-null velocity. Note that the entity may still have a zero velocity; but
-     * it will still be classified as "moving".
+     * non-null velocity. Note that the entity may still have a zero velocity;
+     * but it will still be classified as "moving".
      */
     public boolean isMovingEntity() {
-        return velocity != null;
+        return getVelocity() != null;
     }
 
     /**
@@ -196,7 +160,7 @@ public class WorldEntity implements Serializable {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(position, velocity, extent, properties, elements);
+        return Objects.hash(getPosition(), getVelocity(), getExtent(), getProperties(), getElements());
     }
 
     public WorldEntity deepclone() throws IOException, ClassNotFoundException {
@@ -209,4 +173,79 @@ public class WorldEntity implements Serializable {
         return copied;
     }
 
+    /**
+     * A unique id identifying this entity.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * The type-name of the entity, e.g. "door".
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Represent the last time the state of this entity is sampled.
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * The last time the state of this entity is sampled, after which its state is always sampled
+     * to be the same as its current state (the start of stutter period towards the current state).
+     * If the value is -1, if this time is not known.
+     */
+    public long getLastStutterTimestamp() {
+        return lastStutterTimestamp;
+    }
+
+    public void setLastStutterTimestamp(long lastStutterTimestamp) {
+        this.lastStutterTimestamp = lastStutterTimestamp;
+    }
+
+    /**
+     * The center position of this entity,
+     */
+    public Vec3 getPosition() {
+        return position;
+    }
+
+    public void setPosition(Vec3 position) {
+        this.position = position;
+    }
+
+    /**
+     * Bounding box of this entity.
+     */
+    public Vec3 getExtent() {
+        return extent;
+    }
+
+    public void setExtent(Vec3 extent) {
+        this.extent = extent;
+    }
+
+    public Vec3 getVelocity() {
+        return velocity;
+    }
+
+    public boolean isDynamic() {
+        return dynamic;
+    }
+
+    public Map<String, Serializable> getProperties() {
+        return properties;
+    }
+
+    public Map<String, WorldEntity> getElements() {
+        return elements;
+    }
 }

--- a/src/test/java/eu/iv4xr/framework/mainConcepts/Test_WorldEntity.java
+++ b/src/test/java/eu/iv4xr/framework/mainConcepts/Test_WorldEntity.java
@@ -4,14 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class Test_WorldEntity {
 
     WorldEntity door(String id) {
         WorldEntity e = new WorldEntity(id, "door", true);
-        e.properties.put("isOpen", false);
+        e.getProperties().put("isOpen", false);
         return e;
     }
 
@@ -30,16 +29,16 @@ public class Test_WorldEntity {
         var door1 = door("d1");
         assertTrue(door1.hasSameState(door("d1")));
 
-        door1.properties.put("isOpen", true);
+        door1.getProperties().put("isOpen", true);
         assertFalse(door1.hasSameState(door("d1")));
 
         var bag1 = bag("bag1");
-        bag1.elements.put("excalibur", sword("excalibur"));
+        bag1.getElements().put("excalibur", sword("excalibur"));
         var bag2 = bag("bag1");
-        bag2.elements.put("excalibur", sword("excalibur"));
+        bag2.getElements().put("excalibur", sword("excalibur"));
         assertTrue(bag1.hasSameState(bag2));
 
-        bag2.elements.put("sting", sword("sting"));
+        bag2.getElements().put("sting", sword("sting"));
         assertFalse(bag1.hasSameState(bag2));
 
     }
@@ -47,8 +46,8 @@ public class Test_WorldEntity {
     @Test
     public void test_getProperty() {
         var door = door("d1");
-        door.properties.put("price", 100);
-        door.properties.put("inscription", "goaway");
+        door.getProperties().put("price", 100);
+        door.getProperties().put("inscription", "goaway");
 
         assertTrue(door.getBooleanProperty("isOpen") == false);
         assertTrue(door.getIntProperty("price") == 100);
@@ -69,7 +68,7 @@ public class Test_WorldEntity {
 
         assertFalse(door.hasChangedState());
 
-        door.properties.put("isOpen", true);
+        door.getProperties().put("isOpen", true);
 
         assertTrue(door.hasChangedState());
 


### PR DESCRIPTION
Pull request to give some idea.

Class that I expect represents any game entity. In our case those are mostly blocks (`SeBlock`).
We don't really want to inherit from this class so we use mapping and for every `SeBlock` we create WorldEntity when communicating with Iv4XR framework.

Would be cool, if `WorldEntity` had interface that we can implement rather than extend from class. That way we could return our `SeBlock` directly. Similar mechanism can be applied to many places in framework.